### PR TITLE
Fix reach example.

### DIFF
--- a/src/planner/joint_path_planner.rs
+++ b/src/planner/joint_path_planner.rs
@@ -278,7 +278,9 @@ where
     /// Create from components
     ///
     /// There are also some utility functions to create from urdf
-    pub fn new(collision_check_robot: k::Chain<N>, collision_checker: CollisionChecker<N>) -> Self {
+    pub fn new(urdf_robot: urdf_rs::Robot, collision_checker: CollisionChecker<N>) -> Self {
+        let collision_check_robot = (&urdf_robot).into();
+        let urdf_robot = Some(urdf_robot);
         JointPathPlannerBuilder {
             collision_check_robot,
             collision_checker,
@@ -286,7 +288,7 @@ where
             max_try: 5000,
             num_smoothing: 100,
             collision_check_margin: None,
-            urdf_robot: None,
+            urdf_robot,
             self_collision_pairs: vec![],
         }
     }
@@ -360,10 +362,7 @@ fn get_joint_path_planner_builder_from_urdf<N>(
 where
     N: RealField + k::SubsetOf<f64> + num_traits::Float,
 {
-    Ok(JointPathPlannerBuilder::new(
-        (&urdf_robot).into(),
-        collision_checker,
-    ))
+    Ok(JointPathPlannerBuilder::new(urdf_robot, collision_checker))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
urdf_robot was `None` when being added to the viewer. It did not appear that urdf_robot would ever be `Some` from the current code.

This does break a public API, so an alternative would be to add urdf_robot via a builder method instead if preferred.

If it is ok to break the API I can make `urdf_robot` no longer optional.

Error message:

```
➜  gear git:(master) cargo run --release --example reach
   Compiling gear v0.6.0 (/Users/jon/src/gear)
    Finished release [optimized] target(s) in 14.62s
     Running `target/release/examples/reach`
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', examples/reach.rs:67:40
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```